### PR TITLE
Speed-up CI by pruning unused dependencies

### DIFF
--- a/lib/action-ros2-ci.js
+++ b/lib/action-ros2-ci.js
@@ -45,6 +45,10 @@ repositories:
     url: "https://github.com/${repo["owner"]}/${repo["repo"]}.git"
     version: "${commitRef}"
 EOF`], options);
+            // Remove all repositories the package under test does not depend on, to
+            // avoid having rosdep installing unrequired dependencies.
+            yield exec.exec("bash", ["-c",
+                `diff --new-line-format="" --unchanged-line-format="" <(colcon list -p) <(colcon list --packages-up-to ${packageName} -p) | xargs rm -rf`], options);
             // For "latest" builds, rosdep often misses some keys, adding "|| true", to
             // ignore those failures, as it is often non-critical.
             yield exec.exec("bash", ["-c", "DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes rosdep install -r --from-paths src --ignore-src --rosdistro eloquent -y || true"], options);

--- a/src/action-ros2-ci.ts
+++ b/src/action-ros2-ci.ts
@@ -37,6 +37,14 @@ repositories:
     version: "${commitRef}"
 EOF`], options);
 
+    // Remove all repositories the package under test does not depend on, to
+    // avoid having rosdep installing unrequired dependencies.
+    await exec.exec(
+        "bash",
+        ["-c",
+         `diff --new-line-format="" --unchanged-line-format="" <(colcon list -p) <(colcon list --packages-up-to ${packageName} -p) | xargs rm -rf`],
+        options);
+
     // For "latest" builds, rosdep often misses some keys, adding "|| true", to
     // ignore those failures, as it is often non-critical.
     await exec.exec(


### PR DESCRIPTION
rosdep cannot install dependencies for a subset of a workspace.
Add a line to remove the directories containing repositories
which are not dependend on.

Unfortunately, we need first to clone all repositories, so that
`colcon list` can resolve dependencies.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>