### PR TITLE
Prune package under test from ros2.repos packages

### DIFF
--- a/lib/action-ros2-ci.js
+++ b/lib/action-ros2-ci.js
@@ -32,6 +32,12 @@ function run() {
             };
             yield exec.exec("bash", ["-c",
                 "curl https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos | vcs import src/"], options);
+            // If the package under tests is part of ros2.repos, remove it first.
+            // We do not want to allow the "default" head state of the package to
+            // to be present in the workspace, and colcon will fail stating it found twice
+            // a package with an identical name.
+            yield exec.exec("bash", ["-c",
+                `colcon list --packages-select "${packageName}" -p | xargs rm -rf`]);
             // The repo file for the repository needs to be generated on-the-fly to
             // incorporate the custom repository URL and branch name, when a PR is
             // being built.

--- a/src/action-ros2-ci.ts
+++ b/src/action-ros2-ci.ts
@@ -21,6 +21,15 @@ async function run() {
         "curl https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos | vcs import src/"],
         options);
 
+    // If the package under tests is part of ros2.repos, remove it first.
+    // We do not want to allow the "default" head state of the package to
+    // to be present in the workspace, and colcon will fail stating it found twice
+    // a package with an identical name.
+    await exec.exec(
+        "bash",
+        ["-c",
+         `colcon list --packages-select "${packageName}" -p | xargs rm -rf`]);
+
     // The repo file for the repository needs to be generated on-the-fly to
     // incorporate the custom repository URL and branch name, when a PR is
     // being built.


### PR DESCRIPTION
To use this GitHub action with e.g. rosbag2, we need
to remove the rosbag2 installed by the initial
`curl http:/... | vcs import src/`

This issue is only triggered when a package in ros2.repos
is the package under test.