### PR TITLE
Fix action-ros2-ci.ts to look for correct path

### DIFF
--- a/lib/action-ros2-ci.js
+++ b/lib/action-ros2-ci.js
@@ -22,6 +22,7 @@ const io = __importStar(require("@actions/io"));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            const repo = github.context.repo;
             const packageName = core.getInput("package-name");
             const ros2WorkspaceDir = "/opt/ros2_ws";
             yield exec.exec("rosdep", ["update"]);
@@ -37,16 +38,15 @@ function run() {
             // to be present in the workspace, and colcon will fail stating it found twice
             // a package with an identical name.
             yield exec.exec("bash", ["-c",
-                `colcon list --packages-select "${packageName}" -p | xargs rm -rf`]);
+                `find "${ros2WorkspaceDir}" -type d -and -name "${repo["repo"]}" | xargs rm -rf`]);
             // The repo file for the repository needs to be generated on-the-fly to
             // incorporate the custom repository URL and branch name, when a PR is
             // being built.
-            const repo = github.context.repo;
             const headRef = process.env.GITHUB_HEAD_REF;
             const commitRef = headRef || github.context.sha;
             yield exec.exec("bash", ["-c", `vcs import src/ << EOF
 repositories:
-  ${packageName}:
+  ${repo["repo"]}:
     type: git
     url: "https://github.com/${repo["owner"]}/${repo["repo"]}.git"
     version: "${commitRef}"


### PR DESCRIPTION
Until this commit, action-ros2-ci.js was making the assumption that the
package under test, was also the repository directory name.

This is wrong for repositories containing more than one repo.
For instance, rosbag2 is the repository name, while ros2bag is a package
name in rosbag2.

This commit fixes this incorrect assumption, and enable this
action to work correctly with repositories containing more than
one package.

Testing:

See https://github.com/thomas-moulard/rosbag2/pull/1/checks?check_run_id=270924696
The action worked correctly. The package compilation failed, for
unrelated reasons.