### PR TITLE
Compute C++ code coverage using colcon lcov-result

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - run: npm ci
     - run: npm run build
 
-    - uses: ros-tooling/setup-ros2@master
+    - uses: ros-tooling/setup-ros2@0.0.6
     - uses: ./ # Uses an action in the root directory
       with:
         colcon-mixin-name: asan

--- a/lib/action-ros2-ci.js
+++ b/lib/action-ros2-ci.js
@@ -90,9 +90,13 @@ EOF`], options);
             core.addPath(path.join(ros2WorkspaceDir, "install", "bin"));
             yield exec.exec("colcon", ["build", "--event-handlers", "console_cohesion+", "--packages-up-to",
                 packageName, "--symlink-install"].concat(extra_options), options);
+            yield exec.exec("colcon", ["lcov-result", "--initial"]);
             yield exec.exec("colcon", ["test", "--event-handlers", "console_cohesion+", "--pytest-args",
                 "'--cov=.'", "'--cov-report=xml'", "--packages-select",
                 packageName, "--return-code-on-test-failure"].concat(extra_options), options);
+            // ignoreReturnCode is set to true to avoid  having a lack of coverage
+            // data fail the build.
+            yield exec.exec("colcon", ["lcov-result"], { ignoreReturnCode: true });
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/action-ros2-ci.ts
+++ b/src/action-ros2-ci.ts
@@ -99,12 +99,17 @@ EOF`], options);
         "colcon",
         ["build", "--event-handlers", "console_cohesion+", "--packages-up-to",
         packageName, "--symlink-install"].concat(extra_options), options);
+    await exec.exec("colcon", ["lcov-result", "--initial"]);
     await exec.exec(
         "colcon",
         ["test", "--event-handlers", "console_cohesion+", "--pytest-args",
          "'--cov=.'", "'--cov-report=xml'", "--packages-select",
          packageName, "--return-code-on-test-failure"].concat(extra_options),
         options);
+
+    // ignoreReturnCode is set to true to avoid  having a lack of coverage
+    // data fail the build.
+    await exec.exec("colcon", ["lcov-result"], {ignoreReturnCode: true});
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
For now, always run lcov-result, independently of whether or not it is
a C++ package, to avoid overloading the user with too many flags.
Options to disable this behavior will be added down the road if
necessary.

This follows lcov-test-result tutorial: https://github.com/colcon/colcon-lcov-result