### PR TITLE
Fix error when concatenating colcon build flags

### DIFF
--- a/lib/action-ros2-ci.js
+++ b/lib/action-ros2-ci.js
@@ -72,7 +72,7 @@ EOF`], options);
             }
             let extra_options = [];
             if (colconMixinName !== "") {
-                extra_options.concat(["--mixin", colconMixinName]);
+                extra_options = extra_options.concat(["--mixin", colconMixinName]);
             }
             // Add the future install bin directory to PATH.
             // This enables cmake find_package to find packages installed in the
@@ -90,13 +90,14 @@ EOF`], options);
             core.addPath(path.join(ros2WorkspaceDir, "install", "bin"));
             yield exec.exec("colcon", ["build", "--event-handlers", "console_cohesion+", "--packages-up-to",
                 packageName, "--symlink-install"].concat(extra_options), options);
-            yield exec.exec("colcon", ["lcov-result", "--initial"]);
             yield exec.exec("colcon", ["test", "--event-handlers", "console_cohesion+", "--pytest-args",
                 "'--cov=.'", "'--cov-report=xml'", "--packages-select",
                 packageName, "--return-code-on-test-failure"].concat(extra_options), options);
             // ignoreReturnCode is set to true to avoid  having a lack of coverage
             // data fail the build.
-            yield exec.exec("colcon", ["lcov-result"], { ignoreReturnCode: true });
+            yield exec.exec("colcon", [
+                "lcov-result", "--packages-select", packageName
+            ], { ignoreReturnCode: true });
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/action-ros2-ci.ts
+++ b/src/action-ros2-ci.ts
@@ -77,7 +77,7 @@ EOF`], options);
 
     let extra_options: string[] = [];
     if (colconMixinName !== "") {
-      extra_options.concat(["--mixin", colconMixinName]);
+      extra_options = extra_options.concat(["--mixin", colconMixinName]);
     }
 
     // Add the future install bin directory to PATH.
@@ -99,7 +99,6 @@ EOF`], options);
         "colcon",
         ["build", "--event-handlers", "console_cohesion+", "--packages-up-to",
         packageName, "--symlink-install"].concat(extra_options), options);
-    await exec.exec("colcon", ["lcov-result", "--initial"]);
     await exec.exec(
         "colcon",
         ["test", "--event-handlers", "console_cohesion+", "--pytest-args",
@@ -109,7 +108,10 @@ EOF`], options);
 
     // ignoreReturnCode is set to true to avoid  having a lack of coverage
     // data fail the build.
-    await exec.exec("colcon", ["lcov-result"], {ignoreReturnCode: true});
+    await exec.exec(
+        "colcon", [
+            "lcov-result", "--packages-select", packageName
+        ], {ignoreReturnCode: true});
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
There was a logical error in the code. Instead of writing:

array1 = array1.concat(array2);

...to append array2 to array1. The code was:

array1.concat(array2);

...which does not do anything.

As a result, it was impossible to actually use a mixin.