### PR TITLE
Add assertions to test workflow

### DIFF
--- a/.github/workflows/repo_file_for_test_cpp_package.repos
+++ b/.github/workflows/repo_file_for_test_cpp_package.repos
@@ -1,0 +1,10 @@
+# repo file only containing osrf_testing_tools_cpp
+# This repository has been chosen because it does depend on anything, as of
+# 1.2.1.
+#
+# https://github.com/ament/ament_lint/tree/0.8.1
+repositories:
+  osrf_testing_tools_cpp:
+    type: git
+    url: https://github.com/osrf/osrf_testing_tools_cpp.git
+    version: 1.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,20 @@ jobs:
       name: "Test single package, default options"
       with:
         package-name: ament_copyright
+    - run: test -d "ros2_ws/install/ament_copyright"
+      name: "Check that ament_copyright install directory is present"
+      shell: bash
 
     - uses: ./
       name: "Test multiple package, default options"
       with:
         package-name: ament_copyright ament_lint
+    - run: test -d "ros2_ws/install/ament_copyright"
+      name: "Check that ament_copyright install directory is present"
+      shell: bash
+    - run: test -d "ros2_ws/install/ament_lint"
+      name: "Check that ament_lint install directory is present"
+      shell: bash
 
     - uses: ./
       name: "Test single package, with custom mixin"
@@ -49,14 +58,27 @@ jobs:
         colcon-mixin-name: asan
         colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
         package-name: ament_copyright
+    - run: test -d "ros2_ws/install/ament_copyright"
+      name: "Check that ament_copyright install directory is present"
+      shell: bash
 
     - uses: ./
       name: "Test single package, with custom repository file"
       with:
-        colcon-mixin-repository: .github/workflows/repo_file_for_test.repos
+        vcs-repo-file-url: .github/workflows/repo_file_for_test.repos
         package-name: ament_copyright
+    - run: test -d "ros2_ws/install/ament_copyright"
+      shell: bash
 
-    - uses: actions/upload-artifact@master
+    - uses: ./
+      name: "Test single package, with coverage enabled (Linux only)"
       with:
-        name: colcon-logs
-        path: ros2_ws/log
+        colcon-mixin-name: coverage-gcc
+        colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+        package-name: osrf_testing_tools_cpp
+        vcs-repo-file-url: .github/workflows/repo_file_for_test_cpp_package.repos
+      if: matrix.os != 'windows-latest'
+    - run: find ros2_ws/build -name "*.gcda" | grep -q "."
+      name: "Check if one or more code coverage files (*.gcda) are present (Linux only)"
+      shell: bash
+      if: matrix.os != 'windows-latest'

--- a/dist/index.js
+++ b/dist/index.js
@@ -4778,6 +4778,7 @@ const core = __importStar(__webpack_require__(470));
 const exec = __importStar(__webpack_require__(986));
 const github = __importStar(__webpack_require__(469));
 const io = __importStar(__webpack_require__(1));
+const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 const fs_1 = __importDefault(__webpack_require__(747));
 /**
@@ -4814,6 +4815,11 @@ function run() {
             if (process.platform != "win32") {
                 yield exec.exec("rosdep", ["update"]);
             }
+            // Reset colcon configuration.
+            yield io.rmRF(path.join(os.homedir(), ".colcon"));
+            // Wipe out the workspace directory to ensure the workspace is always
+            // identical.
+            yield io.rmRF(ros2WorkspaceDir);
             // Checkout ROS 2 from source and install ROS 2 system dependencies
             yield io.mkdirP(ros2WorkspaceDir + "/src");
             const options = {

--- a/src/action-ros2-ci.ts
+++ b/src/action-ros2-ci.ts
@@ -2,6 +2,7 @@ import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import * as github from "@actions/github";
 import * as io from "@actions/io";
+import * as os from "os";
 import * as path from "path";
 import fs from "fs";
 
@@ -42,6 +43,13 @@ async function run() {
 		if (process.platform != "win32") {
 			await exec.exec("rosdep", ["update"]);
 		}
+
+		// Reset colcon configuration.
+		await io.rmRF(path.join(os.homedir(), ".colcon"));
+
+		// Wipe out the workspace directory to ensure the workspace is always
+		// identical.
+		await io.rmRF(ros2WorkspaceDir);
 
 		// Checkout ROS 2 from source and install ROS 2 system dependencies
 		await io.mkdirP(ros2WorkspaceDir + "/src");


### PR DESCRIPTION
Actually test the action output in the test workflow to detect failures.
Until now, many types of failures were not detected because the workflow
was only relying on the action failing without verifying whether the
final state of the worker is correct or not.